### PR TITLE
Switch to write and readinto

### DIFF
--- a/adafruit_vl6180x.py
+++ b/adafruit_vl6180x.py
@@ -276,7 +276,8 @@ class VL6180X:
         # Read and return a byte from the specified 16-bit register address.
         with self._device as i2c:
             result = bytearray(1)
-            i2c.write_then_readinto(bytes([(address >> 8) & 0xFF, address & 0xFF]), result)
+            i2c.write(bytes([(address >> 8) & 0xFF, address & 0xFF]))
+            i2c.readinto(result)
             return result[0]
 
     def _read_16(self, address):
@@ -284,5 +285,6 @@ class VL6180X:
         # specified 16-bit register address.
         with self._device as i2c:
             result = bytearray(2)
-            i2c.write_then_readinto(bytes([(address >> 8) & 0xFF, address & 0xFF]), result)
+            i2c.write(bytes([(address >> 8) & 0xFF, address & 0xFF]))
+            i2c.readinto(result)
             return (result[0] << 8) | result[1]


### PR DESCRIPTION
Fix for #7 so it will work on **RPI**:
```console
pi@pizerow:~$ python3 vl6180x_simpletest.py 
Range: 125mm
Light (1x gain): 248.0lux
Range: 102mm
Light (1x gain): 62.4lux
Range: 109mm
Light (1x gain): 34.88lux
```
and still works on **CP**:
```console
Adafruit CircuitPython 4.1.0 on 2019-08-02; Adafruit Metro M4 Airlift Lite with samd51j19
>>> import vl6180x_simpletest
Range: 255mm
Light (1x gain): 366.08lux
Range: 255mm
Light (1x gain): 363.84lux
Range: 132mm
Light (1x gain): 16.0lux
```