### PR TITLE
Add param types to docstrings, use tables

### DIFF
--- a/adafruit_vl6180x.py
+++ b/adafruit_vl6180x.py
@@ -95,12 +95,13 @@ class VL6180X:
     """Create an instance of the VL6180X distance sensor. You must pass in
     the following parameters:
 
-    :param i2c: An instance of the I2C bus connected to the sensor.
+    :param ~I2C i2c: An instance of the I2C bus connected to the sensor.
 
     Optionally you can specify:
 
-    :param address: The I2C address of the sensor.  If not specified the sensor's
+    :param int address: The I2C address of the sensor.  If not specified the sensor's
                     default value will be assumed.
+    :param int offset: The offset to be applied to measurements, in mm
     """
 
     def __init__(
@@ -168,7 +169,8 @@ class VL6180X:
 
     def start_range_continuous(self, period: int = 100) -> None:
         """Start continuous range mode
-        :param period: Time delay between measurements in ms
+
+        :param int period: Time delay between measurements, in milliseconds
         """
         # Set range between measurements
         period_reg: int = 0
@@ -238,6 +240,8 @@ class VL6180X:
         - ALS_GAIN_10 = 10x
         - ALS_GAIN_20 = 20x
         - ALS_GAIN_40 = 40x
+
+        :param int gain: The gain value to use
         """
         reg = self._read_8(_VL6180X_REG_SYSTEM_INTERRUPT_CONFIG)
         reg &= ~0x38

--- a/adafruit_vl6180x.py
+++ b/adafruit_vl6180x.py
@@ -232,16 +232,22 @@ class VL6180X:
     def read_lux(self, gain: int) -> float:
         """Read the lux (light value) from the sensor and return it.  Must
         specify the gain value to use for the lux reading:
-        - ALS_GAIN_1 = 1x
-        - ALS_GAIN_1_25 = 1.25x
-        - ALS_GAIN_1_67 = 1.67x
-        - ALS_GAIN_2_5 = 2.5x
-        - ALS_GAIN_5 = 5x
-        - ALS_GAIN_10 = 10x
-        - ALS_GAIN_20 = 20x
-        - ALS_GAIN_40 = 40x
+
+        =================  =====
+             Setting       Value
+        =================  =====
+        ``ALS_GAIN_1``     1x
+        ``ALS_GAIN_1_25``  1.25x
+        ``ALS_GAIN_1_67``  1.67x
+        ``ALS_GAIN_2_5``   2.5x
+        ``ALS_GAIN_5``     5x
+        ``ALS_GAIN_10``    10x
+        ``ALS_GAIN_20``    20x
+        ``ALS_GAIN_40``    40x
+        =================  =====
 
         :param int gain: The gain value to use
+
         """
         reg = self._read_8(_VL6180X_REG_SYSTEM_INTERRUPT_CONFIG)
         reg &= ~0x38
@@ -290,17 +296,22 @@ class VL6180X:
         """Retrieve the status/error from a previous range read.  This will
         return a constant value such as:
 
-        - ERROR_NONE - No error
-        - ERROR_SYSERR_1 - System error 1 (see datasheet)
-        - ERROR_SYSERR_5 - System error 5 (see datasheet)
-        - ERROR_ECEFAIL - ECE failure
-        - ERROR_NOCONVERGE - No convergence
-        - ERROR_RANGEIGNORE - Outside range ignored
-        - ERROR_SNR - Too much noise
-        - ERROR_RAWUFLOW - Raw value underflow
-        - ERROR_RAWOFLOW - Raw value overflow
-        - ERROR_RANGEUFLOW - Range underflow
-        - ERROR_RANGEOFLOW - Range overflow
+        =====================  ==============================
+                Error                   Description
+        =====================  ==============================
+        ``ERROR_NONE``         No error
+        ``ERROR_SYSERR_1``     System error 1 (see datasheet)
+        ``ERROR_SYSERR_5``     System error 5 (see datasheet)
+        ``ERROR_ECEFAIL``      ECE failure
+        ``ERROR_NOCONVERGE``   No convergence
+        ``ERROR_RANGEIGNORE``  Outside range ignored
+        ``ERROR_SNR``          Too much noise
+        ``ERROR_RAWUFLOW``     Raw value underflow
+        ``ERROR_RAWOFLOW``     Raw value overflow
+        ``ERROR_RANGEUFLOW``   Range underflow
+        ``ERROR_RANGEOFLOW``   Range overflow
+        =====================  ==============================
+
         """
         return self._read_8(_VL6180X_REG_RESULT_RANGE_STATUS) >> 4
 


### PR DESCRIPTION
1. Adds param types to the docstrings
2. Converts the gain and error descriptions to use table markup (error wasn't rendering properly as a list as is)
3. Should resolve #24 by rebuilding the documentation