### PR TITLE
Fix example code usage of start_range_continuous()

### DIFF
--- a/examples/vl6180x_performancetest.py
+++ b/examples/vl6180x_performancetest.py
@@ -39,7 +39,7 @@ time.sleep(2)
 
 # Continuous with no delay between measurements
 print("Starting continuous measurement...")
-sensor.start_range_continuous(0)
+sensor.start_range_continuous(20)
 start = time.time()
 for i in range(n_measurements):
     range_mm = sensor.range


### PR DESCRIPTION
While `start_range_continuous(0)` will work, it silently changes the delay to 10 ms.  This changes it to be more sensible by setting it within the intended range.