### PR TITLE
Add ValueError to start_range_continuous()

### DIFF
--- a/adafruit_vl6180x.py
+++ b/adafruit_vl6180x.py
@@ -170,15 +170,16 @@ class VL6180X:
     def start_range_continuous(self, period: int = 100) -> None:
         """Start continuous range mode
 
-        :param int period: Time delay between measurements, in milliseconds
+        :param int period: Time delay between measurements, in milliseconds; the value you will be floored
+            to the nearest 10 milliseconds (setting to 157 ms sets it to 150 ms).  Range is 10 - 2550 ms.
         """
         # Set range between measurements
-        period_reg: int = 0
-        if period > 10:
-            if period < 2250:
-                period_reg = (period // 10) - 1
-            else:
-                period_reg = 254
+        if not 10 <= period <= 2550:
+            raise ValueError(
+                "Delay must be in 10 millisecond increments between 10 and 2550 milliseconds"
+            )
+
+        period_reg = (period // 10) - 1
         self._write_8(_VL6180X_REG_SYSRANGE_INTERMEASUREMENT_PERIOD, period_reg)
 
         # Start continuous range measurement

--- a/adafruit_vl6180x.py
+++ b/adafruit_vl6180x.py
@@ -170,8 +170,9 @@ class VL6180X:
     def start_range_continuous(self, period: int = 100) -> None:
         """Start continuous range mode
 
-        :param int period: Time delay between measurements, in milliseconds; the value you will be floored
-            to the nearest 10 milliseconds (setting to 157 ms sets it to 150 ms).  Range is 10 - 2550 ms.
+        :param int period: Time delay between measurements, in milliseconds; the value you
+            will be floored to the nearest 10 milliseconds (setting to 157 ms sets it to 150
+            ms). Range is 10 - 2550 ms.
         """
         # Set range between measurements
         if not 10 <= period <= 2550:


### PR DESCRIPTION
Refactors `start_range_continuous()` and also adds throwing ValueError if out of range.  Not sure why the period couldn't be set specifically between 2.25 and 2.54 seconds, but that was also removed and can now be done (in the 10 ms intervals)

Also updates the documentation to add more information on the delay behavior.