### PR TITLE
minimum 20ms continuous read mode

### DIFF
--- a/adafruit_vl6180x.py
+++ b/adafruit_vl6180x.py
@@ -172,12 +172,12 @@ class VL6180X:
 
         :param int period: Time delay between measurements, in milliseconds; the value you
             will be floored to the nearest 10 milliseconds (setting to 157 ms sets it to 150
-            ms). Range is 10 - 2550 ms.
+            ms). Range is 20 - 2550 ms.
         """
         # Set range between measurements
-        if not 10 <= period <= 2550:
+        if not 20 <= period <= 2550:
             raise ValueError(
-                "Delay must be in 10 millisecond increments between 10 and 2550 milliseconds"
+                "Delay must be in 10 millisecond increments between 20 and 2550 milliseconds"
             )
 
         period_reg = (period // 10) - 1


### PR DESCRIPTION
@ladyada 

Resolves: #26 

In testing I did see the device get locked up when set to 10ms continuous read mode. For me it was hanging forever getting stuck [inside of this loop](https://github.com/adafruit/Adafruit_CircuitPython_VL6180X/blob/ddf5087579e8de4210e905aebb648926b2438c5e/adafruit_vl6180x.py#L223-L224) when this happened. I tried a few ideas to make it sort of timeout if it gets stuck in that loop, but was unsuccessful with a few quick attempts. 

Using 20ms instead seems to alleviate the problem, I have not had it lock up once on this setting. I believe this is what was being recommended by the comments in the issue. 

This change enforces a 20ms minimum on for the continuous read setting.